### PR TITLE
add trigger to gear_list table to cap table to 30 items

### DIFF
--- a/src/data/data.py
+++ b/src/data/data.py
@@ -27,6 +27,16 @@ def init_db():
         """)
 
         cursor.execute("""
+            CREATE TRIGGER IF NOT EXISTS limit_gear_list_to_thirty_items
+            AFTER INSERT ON gear_list
+            WHEN (SELECT COUNT(*) FROM gear_list) > 30
+            BEGIN
+                DELETE FROM gear_list
+                WHERE id IN (SELECT id FROM GEAR_LIST ORDER BY id ASC LIMIT (SELECT COUNT(*) FROM gear_list) - 30);
+            END;
+        """)
+
+        cursor.execute("""
             CREATE TABLE IF NOT EXISTS gear_queries (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 search_term TEXT,
@@ -67,9 +77,7 @@ def execute_sql_query(
 
     execute_many: false uses execute for single value,
         true uses execute for a list of tuples.
-    is_select: True to fetch all results from a SELECT query
-
-
+    is_select: True to fetch all results from a SELECT query3
     """
     try:
         with sqlite3.connect(GEAR_DB) as connection:

--- a/src/data/fetch.py
+++ b/src/data/fetch.py
@@ -6,9 +6,9 @@ from .data import execute_sql_query
 
 
 def fetch_gear_queries():
-    """Fetch all gear queries"""
+    """Fetch all gear queries."""
     return execute_sql_query("SELECT * FROM gear_queries", is_select=True)
 
 def fetch_gear_list():
-    """Fetch all items in gear list table"""
+    """Fetch all items in gear list table."""
     return execute_sql_query("SELECT * FROM gear_list", is_select=True)

--- a/src/data/post.py
+++ b/src/data/post.py
@@ -6,13 +6,18 @@ from .data import execute_sql_query
 
 
 def post_gear_query(search_term: str, timestamp: str):
-    """Post gear query to gear_queries table"""
+    """Post gear query to gear_queries table."""
     query_values = (search_term, timestamp)
     sql_query = "INSERT INTO gear_queries (search_term, timestamp) VALUES (?, ?)"
     execute_sql_query(sql_query, query_values)
 
 def post_gear_list(gear_list: list):
-    """"Post all items in gear_list to gear_list table"""
+    """"
+    Post all items in gear_list to gear_list table.
+    Reverses gear list to order items oldest to newest in database so trigger
+    can maintain 30 item cap. Oldest items out first.
+    """
+    gear_list.reverse()
     gear_tuples = [
         (gear["name"], gear["price"], gear["link"])
         for gear in gear_list
@@ -22,7 +27,7 @@ def post_gear_list(gear_list: list):
 
 
 def post_gear_matches(gear_matches: list):
-    """Post gear matches to database"""
+    """Post gear matches to database."""
     match_tuples = [
         (match["name"], match["price"], match["link"], match["query_id"])
         for match in gear_matches


### PR DESCRIPTION
Limits gear_list table to 30 items so `update_matches` is run, we only compare against current latest items scraped from the latest gear page.